### PR TITLE
feat: add KubeStellar Console to dashboards list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Vue Paper Dashboard | [cristijora/vue-paper-dashboard](https://github.com/cristi
 Vue Element Admin | [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin) | _vuejs_
 Volt Bootstrap 5 Dashboard | [themesberg/volt-bootstrap-5-dashboard](https://github.com/themesberg/volt-bootstrap-5-dashboard) | _bootstrap_ _bootstrap5_ _Sass_
 Material Dashboard | [creativetimofficial/material-dashboard](https://github.com/creativetimofficial/material-dashboard) | _bootstrap_
+
+KubeStellar Console | [kubestellar/console](https://github.com/kubestellar/console) | _kubernetes_ _multi-cluster_ _ai_ _cncf_ _observability_


### PR DESCRIPTION
Adds KubeStellar Console — an AI-powered multi-cluster Kubernetes dashboard (CNCF Sandbox, free/open source) — to the dashboards list. Tags: kubernetes, multi-cluster, ai, cncf, observability. https://github.com/kubestellar/console